### PR TITLE
Updated reek compatibility version

### DIFF
--- a/lib/metric_fu/metrics/reek/generator.rb
+++ b/lib/metric_fu/metrics/reek/generator.rb
@@ -15,11 +15,16 @@ module MetricFu
     end
 
     def run!(files, config_files)
-      examiner.new(files, config_files)
+      smells = []
+      files.each do |file|
+        e = examiner.new(File.new(file))
+        smells += e.smells
+      end
+      smells
     end
 
     def analyze
-      @matches = @output.smells.group_by(&:source).collect do |file_path, smells|
+      @matches = @output.group_by(&:source).collect do |file_path, smells|
         { file_path: file_path,
           code_smells: analyze_smells(smells) }
       end

--- a/lib/metric_fu/version.rb
+++ b/lib/metric_fu/version.rb
@@ -1,7 +1,7 @@
 module MetricFu
   class Version
     MAJOR = "4"
-    MINOR = "12"
+    MINOR = "13"
     PATCH = "0"
     PRE   = ""
   end

--- a/metric_fu.gemspec
+++ b/metric_fu.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "flay",                  [">= 2.0.1",  "~> 2.1"]
   s.add_runtime_dependency "churn",                 ["~> 0.0.35"]
   s.add_runtime_dependency "flog",                  [">= 4.1.1",  "~> 4.1"]
-  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 3.0"]
+  s.add_runtime_dependency "reek",                  [">= 1.3.4",  "< 5.0"]
   s.add_runtime_dependency "cane",                  [">= 2.5.2",  "~> 2.5"]
   s.add_runtime_dependency "rails_best_practices",  [">= 1.14.3", "~> 1.14"]
   s.add_runtime_dependency "metric_fu-Saikuro",     [">= 1.1.3",  "~> 1.1"]


### PR DESCRIPTION
Reek examiner interface changed, and we needed to update the source code. Now metric_fu is compatible with ruby 2.4.x also.